### PR TITLE
Fix empty `nf_name` string causing per-secondary conn_table hash name collision (add null-termination + safer snprintf)Fix nf name

### DIFF
--- a/onvm_poller.c
+++ b/onvm_poller.c
@@ -438,7 +438,7 @@ int onvm_init(struct onvm_nf_local_ctx **nf_local_ctx, char *nfName)
         }
     }
 
-    pktmbuf_pool = rte_mempool_lookup(PKTMBUF_POOL_NAME);
+    pktmbuf_pool = rte_mempool_lookup(CP_PKTMBUF_POOL_NAME);
     if (pktmbuf_pool == NULL)
     {
         onvm_nflib_stop(*nf_local_ctx);

--- a/onvm_poller.c
+++ b/onvm_poller.c
@@ -395,8 +395,9 @@ int onvm_init(struct onvm_nf_local_ctx **nf_local_ctx, char *nfName)
     printf("[NF Name]: %s\n", nfName);
     const char *NF_TAG = nfName;
     int nfName_size = string_len(nfName);
-    char nf_name[nfName_size];
+    char nf_name[nfName_size + 1];
     memcpy(nf_name, nfName, nfName_size);
+    nf_name[nfName_size] = '\0';
 
     int arg_offset;
     struct onvm_nf_function_table *nf_function_table;
@@ -417,10 +418,16 @@ int onvm_init(struct onvm_nf_local_ctx **nf_local_ctx, char *nfName)
 
     char cmd0[] = "./go.sh";
     char cmd1[] = "-F";
-    char cmd2[path_len + nfName_size + 5];
-    sprintf(cmd2, "%s%s.json", file_path, nf_name);
+    //char cmd2[path_len + nfName_size + 5];
+    size_t cmd2_len = strlen(file_path) + strlen(nf_name) + strlen(".json") + 1;
+    char cmd2[cmd2_len];
+    snprintf(cmd2, sizeof(cmd2), "%s%s.json", file_path, nf_name);
+
+    //sprintf(cmd2, "%s%s.json", file_path, nf_name);
     char *argv[] = {cmd0, cmd1, cmd2};
     printf("Config file: %s\n", cmd2);
+    printf("nf_name now: '%s' (len=%zu)\n", nf_name, strlen(nf_name));
+
 
     // Initialize ONVM
     arg_offset = onvm_nflib_init(argc, argv, NF_TAG, *nf_local_ctx, nf_function_table);
@@ -437,17 +444,22 @@ int onvm_init(struct onvm_nf_local_ctx **nf_local_ctx, char *nfName)
             rte_exit(EXIT_FAILURE, "Failed ONVM init\n");
         }
     }
-
+printf("AKJSHDKHSADLHLJLlk;lj \n");
     pktmbuf_pool = rte_mempool_lookup(CP_PKTMBUF_POOL_NAME);
     if (pktmbuf_pool == NULL)
     {
         onvm_nflib_stop(*nf_local_ctx);
         rte_exit(EXIT_FAILURE, "Cannot find mbuf pool!\n");
     }
-
+printf("HEYHEY\n");
     /* Create connection look-up table */
-    char conn_table_name[nfName_size + 11];
-    sprintf(conn_table_name, "conn_table_%s", nf_name);
+size_t conn_len = strlen("conn_table_") + strlen(nf_name) + 1;
+char conn_table_name[conn_len];
+snprintf(conn_table_name, sizeof(conn_table_name), "conn_table_%s", nf_name);
+
+    //char conn_table_name[nfName_size + 11];
+    //sprintf(conn_table_name, "conn_table_%s", nf_name);
+    printf("conn_table_name: %s\n", conn_table_name);
     struct rte_hash_parameters xio_ipv4_hash_params = {
         .name = conn_table_name,
         .entries = 1024 * 1024 * 1,
@@ -459,7 +471,7 @@ int onvm_init(struct onvm_nf_local_ctx **nf_local_ctx, char *nfName)
     conn_tables = rte_hash_create(&xio_ipv4_hash_params);
     if (conn_tables == NULL)
     {
-        rte_exit(EXIT_FAILURE, "Unable to create the connection lookup table\n");
+        rte_exit(EXIT_FAILURE, "Unable to create the connection lookup table [%s]\n", nf_name);
     }
 
     // Create udp conn talbe

--- a/onvm_poller.c
+++ b/onvm_poller.c
@@ -418,16 +418,11 @@ int onvm_init(struct onvm_nf_local_ctx **nf_local_ctx, char *nfName)
 
     char cmd0[] = "./go.sh";
     char cmd1[] = "-F";
-    //char cmd2[path_len + nfName_size + 5];
     size_t cmd2_len = strlen(file_path) + strlen(nf_name) + strlen(".json") + 1;
     char cmd2[cmd2_len];
     snprintf(cmd2, sizeof(cmd2), "%s%s.json", file_path, nf_name);
-
-    //sprintf(cmd2, "%s%s.json", file_path, nf_name);
     char *argv[] = {cmd0, cmd1, cmd2};
     printf("Config file: %s\n", cmd2);
-    printf("nf_name now: '%s' (len=%zu)\n", nf_name, strlen(nf_name));
-
 
     // Initialize ONVM
     arg_offset = onvm_nflib_init(argc, argv, NF_TAG, *nf_local_ctx, nf_function_table);
@@ -444,21 +439,18 @@ int onvm_init(struct onvm_nf_local_ctx **nf_local_ctx, char *nfName)
             rte_exit(EXIT_FAILURE, "Failed ONVM init\n");
         }
     }
-printf("AKJSHDKHSADLHLJLlk;lj \n");
+
     pktmbuf_pool = rte_mempool_lookup(CP_PKTMBUF_POOL_NAME);
     if (pktmbuf_pool == NULL)
     {
         onvm_nflib_stop(*nf_local_ctx);
         rte_exit(EXIT_FAILURE, "Cannot find mbuf pool!\n");
     }
-printf("HEYHEY\n");
-    /* Create connection look-up table */
-size_t conn_len = strlen("conn_table_") + strlen(nf_name) + 1;
-char conn_table_name[conn_len];
-snprintf(conn_table_name, sizeof(conn_table_name), "conn_table_%s", nf_name);
 
-    //char conn_table_name[nfName_size + 11];
-    //sprintf(conn_table_name, "conn_table_%s", nf_name);
+    /* Create connection look-up table */
+    size_t conn_len = strlen("conn_table_") + strlen(nf_name) + 1;
+    char conn_table_name[conn_len];
+    snprintf(conn_table_name, sizeof(conn_table_name), "conn_table_%s", nf_name);
     printf("conn_table_name: %s\n", conn_table_name);
     struct rte_hash_parameters xio_ipv4_hash_params = {
         .name = conn_table_name,


### PR DESCRIPTION
This PR fixes a bug where `nf_name` is constructed via `memcpy()` without allocating space for (and appending) the terminating `'\0'`. As a result, `nf_name` is not a valid C string and may appear empty/garbled after subsequent function calls (undefined behavior). In our multi-process DPDK setup, this led to different secondary processes generating the same hash table name (e.g., `conn_table_`), causing `rte_hash_create()` to fail due to name collisions / shared memzone conflicts.

### Root cause

* `char nf_name[nfName_size];` does not reserve space for `'\0'`
* `memcpy(nf_name, nfName, nfName_size);` does not append `'\0'`
* `sprintf(..., "%s", nf_name)` reads beyond bounds until a random `'\0'` is encountered (UB)

### Changes

* Allocate `nf_name` with `nfName_size + 1` and explicitly add `nf_name[nfName_size] = '\0'`
* Replace `sprintf()` with `snprintf()` for `cmd2` and `conn_table_name` to avoid buffer overflows
* Compute buffer sizes using `strlen()` + constants + `1` for null terminator
* (Optional) Add debug prints to validate `nf_name` and generated table/config names during init (can be removed if you prefer)

### Impact

* Each NF instance (secondary process) now generates a stable, unique hash name: `conn_table_<nf_name>`
* Avoids unintended name collisions and subsequent `rte_hash_create()` failures in multi-process mode
* Removes undefined behavior from string handling

### How to test

1. Launch multiple secondary processes with different `nfName` values.
2. Verify logs show distinct `conn_table_name` values.
3. Confirm `rte_hash_create()` succeeds and no “Cannot reserve memory” / collision-related errors occur.
